### PR TITLE
Fix placement bug when using inline=false with popModal.

### DIFF
--- a/popModal.js
+++ b/popModal.js
@@ -217,7 +217,7 @@ Github: https://github.com/vadimsva/popModal
 			eMTop = parseInt(elem.css('marginTop')),
 			eHeight = elem.outerHeight(),
 			eWidth = elem.outerWidth(),
-			eObjWidth,
+			eObjWidth = elemObj.outerWidth(),
 			eObjHeight = elemObj.outerHeight();
 			
 			var placement,


### PR DESCRIPTION
If you use popModal and sets the property inline to false the popModal will not get a correct horizontal placement.
